### PR TITLE
Disable stories UI and remove My Stories template

### DIFF
--- a/Signal/src/ViewControllers/HomeView/HomeTabBarController.swift
+++ b/Signal/src/ViewControllers/HomeView/HomeTabBarController.swift
@@ -135,17 +135,15 @@ class HomeTabBarController: UITabBarController {
     var owsTabBar: OWSTabBar? {
         return tabBar as? OWSTabBar
     }
-
-    private lazy var storyBadgeCountManager = StoryBadgeCountManager()
+    // private lazy var storyBadgeCountManager = StoryBadgeCountManager()
 
     override func viewDidLoad() {
         super.viewDidLoad()
 
         delegate = self
-
-        NotificationCenter.default.addObserver(self, selector: #selector(storiesEnabledStateDidChange), name: .storiesEnabledStateDidChange, object: nil)
+        // NotificationCenter.default.addObserver(self, selector: #selector(storiesEnabledStateDidChange), name: .storiesEnabledStateDidChange, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(applyTheme), name: .themeDidChange, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(didEnterForeground), name: .OWSApplicationWillEnterForeground, object: nil)
+        // NotificationCenter.default.addObserver(self, selector: #selector(didEnterForeground), name: .OWSApplicationWillEnterForeground, object: nil)
         applyTheme()
 
         // We read directly from the database here, as the cache may not have been warmed by the time
@@ -156,17 +154,17 @@ class HomeTabBarController: UITabBarController {
         updateTabBars(areStoriesEnabled: areStoriesEnabled)
 
         AppEnvironment.shared.badgeManager.addObserver(self)
-        storyBadgeCountManager.beginObserving(observer: self)
+        // storyBadgeCountManager.beginObserving(observer: self)
 
         setTabBarHidden(false, animated: false)
     }
 
-    @objc
-    private func didEnterForeground() {
-        if selectedHomeTab == .stories {
-            storyBadgeCountManager.markAllStoriesRead()
-        }
-    }
+    // @objc
+    // private func didEnterForeground() {
+    //     if selectedHomeTab == .stories {
+    //         storyBadgeCountManager.markAllStoriesRead()
+    //     }
+    // }
 
     @objc
     private func applyTheme() {
@@ -213,23 +211,24 @@ class HomeTabBarController: UITabBarController {
     }
 
     private func tabsToShow(areStoriesEnabled: Bool) -> [Tabs] {
-        var tabs = [Tabs.chatList, Tabs.calls]
-        if areStoriesEnabled {
-            tabs.append(Tabs.stories)
-        }
-        return tabs
+        // var tabs = [Tabs.chatList, Tabs.calls]
+        // if areStoriesEnabled {
+        //     tabs.append(Tabs.stories)
+        // }
+        // return tabs
+        // Stories are disabled, so only show chats and calls.
+        return [Tabs.chatList, Tabs.calls]
     }
 
-    @objc
-    private func storiesEnabledStateDidChange() {
-        updateTabBars(areStoriesEnabled: StoryManager.areStoriesEnabled)
-        if selectedHomeTab == .stories {
-            storiesNavController.popToRootViewController(animated: false)
-        }
-
-        selectedHomeTab = .chatList
-        setTabBarHidden(false, animated: false)
-    }
+    // @objc
+    // private func storiesEnabledStateDidChange() {
+    //     updateTabBars(areStoriesEnabled: StoryManager.areStoriesEnabled)
+    //     if selectedHomeTab == .stories {
+    //         storiesNavController.popToRootViewController(animated: false)
+    //     }
+    //     selectedHomeTab = .chatList
+    //     setTabBarHidden(false, animated: false)
+    // }
 
     // MARK: - Hiding the tab bar
 
@@ -311,41 +310,40 @@ extension HomeTabBarController: BadgeObserver {
     }
 }
 
-extension HomeTabBarController: StoryBadgeCountObserver {
-
-    public var isStoriesTabActive: Bool {
-        return selectedHomeTab == .stories && CurrentAppContext().isAppForegroundAndActive()
-    }
-
-    public func didUpdateStoryBadge(_ badge: String?) {
-        if #available(iOS 18, *), UIDevice.current.isIPad {
-            uiTab(for: .stories).badgeValue = badge
-        } else {
-            storiesTabBarItem.badgeValue = badge
-        }
-        var views: [UIView] = [tabBar]
-        var badgeViews = [UIView]()
-        while let view = views.popLast() {
-            if NSStringFromClass(view.classForCoder) == "_UIBadgeView" {
-                badgeViews.append(view)
-            }
-            views = view.subviews + views
-        }
-        let sortedBadgeViews = badgeViews.sorted { lhs, rhs in
-            let lhsX = view.convert(CGPoint.zero, from: lhs).x
-            let rhsX = view.convert(CGPoint.zero, from: rhs).x
-            if CurrentAppContext().isRTL {
-                return lhsX > rhsX
-            } else {
-                return lhsX < rhsX
-            }
-        }
-        let badgeView = sortedBadgeViews[safe: Tabs.stories.rawValue]
-        badgeView?.layer.transform = CATransform3DIdentity
-        let xOffset: CGFloat = CurrentAppContext().isRTL ? 0 : -5
-        badgeView?.layer.transform = CATransform3DMakeTranslation(xOffset, 1, 1)
-    }
-}
+// extension HomeTabBarController: StoryBadgeCountObserver {
+//     public var isStoriesTabActive: Bool {
+//         return selectedHomeTab == .stories && CurrentAppContext().isAppForegroundAndActive()
+//     }
+//
+//     public func didUpdateStoryBadge(_ badge: String?) {
+//         if #available(iOS 18, *), UIDevice.current.isIPad {
+//             uiTab(for: .stories).badgeValue = badge
+//         } else {
+//             storiesTabBarItem.badgeValue = badge
+//         }
+//         var views: [UIView] = [tabBar]
+//         var badgeViews = [UIView]()
+//         while let view = views.popLast() {
+//             if NSStringFromClass(view.classForCoder) == "_UIBadgeView" {
+//                 badgeViews.append(view)
+//             }
+//             views = view.subviews + views
+//         }
+//         let sortedBadgeViews = badgeViews.sorted { lhs, rhs in
+//             let lhsX = view.convert(CGPoint.zero, from: lhs).x
+//             let rhsX = view.convert(CGPoint.zero, from: rhs).x
+//             if CurrentAppContext().isRTL {
+//                 return lhsX > rhsX
+//             } else {
+//                 return lhsX < rhsX
+//             }
+//         }
+//         let badgeView = sortedBadgeViews[safe: Tabs.stories.rawValue]
+//         badgeView?.layer.transform = CATransform3DIdentity
+//         let xOffset: CGFloat = CurrentAppContext().isRTL ? 0 : -5
+//         badgeView?.layer.transform = CATransform3DMakeTranslation(xOffset, 1, 1)
+//     }
+// }
 
 extension HomeTabBarController: UITabBarControllerDelegate {
     func tabBarController(_ tabBarController: UITabBarController, shouldSelect viewController: UIViewController) -> Bool {
@@ -368,9 +366,9 @@ extension HomeTabBarController: UITabBarControllerDelegate {
     }
 
     func tabBarController(_ tabBarController: UITabBarController, didSelect viewController: UIViewController) {
-        if isStoriesTabActive {
-            storyBadgeCountManager.markAllStoriesRead()
-        }
+        // if isStoriesTabActive {
+        //     storyBadgeCountManager.markAllStoriesRead()
+        // }
     }
 }
 

--- a/SignalServiceKit/Messages/Stories/StoryManager.swift
+++ b/SignalServiceKit/Messages/Stories/StoryManager.swift
@@ -13,6 +13,10 @@ public class StoryManager {
         cacheAreStoriesEnabled()
         cacheAreViewReceiptsEnabled()
 
+        // Stories are disabled by default. Only create story related threads
+        // if the feature has been explicitly enabled.
+        guard areStoriesEnabled else { return }
+
         appReadiness.runNowOrWhenAppDidBecomeReadyAsync {
             SSKEnvironment.shared.databaseStorageRef.asyncWrite { transaction in
                 // Create My Story thread if necessary
@@ -306,7 +310,9 @@ extension StoryManager {
     private static let keyValueStore = KeyValueStore(collection: "StoryManager")
     private static let areStoriesEnabledKey = "areStoriesEnabled"
 
-    private static var areStoriesEnabledCache = AtomicBool(true, lock: .sharedGlobal)
+    // Disable stories by default for this application build.
+    // private static var areStoriesEnabledCache = AtomicBool(true, lock: .sharedGlobal)
+    private static var areStoriesEnabledCache = AtomicBool(false, lock: .sharedGlobal)
 
     /// A cache of if stories are enabled for the local user. For convenience, this also factors in whether the overall feature is available to the user.
     public static var areStoriesEnabled: Bool { areStoriesEnabledCache.get() }
@@ -326,7 +332,8 @@ extension StoryManager {
 
     /// Have stories been enabled by the local user. This never factors in any remote information, like is the feature available to the user.
     public static func areStoriesEnabled(transaction: DBReadTransaction) -> Bool {
-        keyValueStore.getBool(areStoriesEnabledKey, defaultValue: true, transaction: transaction)
+        // keyValueStore.getBool(areStoriesEnabledKey, defaultValue: true, transaction: transaction)
+        keyValueStore.getBool(areStoriesEnabledKey, defaultValue: false, transaction: transaction)
     }
 
     private static func cacheAreStoriesEnabled() {


### PR DESCRIPTION
## Summary
- default StoryManager stories setting disabled to hide stories features
- Tab bar now only shows chats and calls, omitting stories
- All story-related UI code commented out rather than removed for future reference

## Testing
- `bundle exec fastlane test` *(fails: Could not find lane 'ios test')*

------
https://chatgpt.com/codex/tasks/task_e_688decf4f6808327b1bffb0b65aac86a