### PR TITLE
Hide donation, stories, and payments from settings

### DIFF
--- a/Signal/src/ViewControllers/AppSettings/AppSettingsViewController.swift
+++ b/Signal/src/ViewControllers/AppSettings/AppSettingsViewController.swift
@@ -174,27 +174,27 @@ class AppSettingsViewController: OWSTableViewController2 {
                 }
             ))
         }
-        section1.add(.init(customCellBlock: { [weak self] in
-            guard let self = self else { return UITableViewCell() }
-            let accessoryContentView: UIView?
-            if self.hasExpiredGiftBadge {
-                let imageView = UIImageView(image: UIImage(imageLiteralResourceName: "info-fill"))
-                imageView.tintColor = Theme.accentBlueColor
-                imageView.autoSetDimensions(to: CGSize(square: 24))
-                accessoryContentView = imageView
-            } else {
-                accessoryContentView = nil
-            }
-            return OWSTableItem.buildCell(
-                icon: .settingsDonate,
-                itemName: OWSLocalizedString("SETTINGS_DONATE", comment: "Title for the 'donate to signal' link in settings."),
-                accessoryType: .disclosureIndicator,
-                accessoryContentView: accessoryContentView,
-                accessibilityIdentifier: UIView.accessibilityIdentifier(in: self, name: "donate")
-            )
-        }, actionBlock: { [weak self] in
-            self?.didTapDonate()
-        }))
+//         section1.add(.init(customCellBlock: { [weak self] in
+//             guard let self = self else { return UITableViewCell() }
+//             let accessoryContentView: UIView?
+//             if self.hasExpiredGiftBadge {
+//                 let imageView = UIImageView(image: UIImage(imageLiteralResourceName: "info-fill"))
+//                 imageView.tintColor = Theme.accentBlueColor
+//                 imageView.autoSetDimensions(to: CGSize(square: 24))
+//                 accessoryContentView = imageView
+//             } else {
+//                 accessoryContentView = nil
+//             }
+//             return OWSTableItem.buildCell(
+//                 icon: .settingsDonate,
+//                 itemName: OWSLocalizedString("SETTINGS_DONATE", comment: "Title for the 'donate to signal' link in settings."),
+//                 accessoryType: .disclosureIndicator,
+//                 accessoryContentView: accessoryContentView,
+//                 accessibilityIdentifier: UIView.accessibilityIdentifier(in: self, name: "donate")
+//             )
+//         }, actionBlock: { [weak self] in
+//             self?.didTapDonate()
+//         }))
         contents.add(section1)
 
         let section2 = OWSTableSection()
@@ -214,17 +214,17 @@ class AppSettingsViewController: OWSTableViewController2 {
                 self?.navigationController?.pushViewController(vc, animated: true)
             }
         ))
-        section2.add(.disclosureItem(
-            icon: .settingsStories,
-            withText: OWSLocalizedString(
-                "STORY_SETTINGS_TITLE",
-                comment: "Label for the stories section of the settings view"
-            ),
-            actionBlock: { [weak self] in
-                let vc = StoryPrivacySettingsViewController()
-                self?.navigationController?.pushViewController(vc, animated: true)
-            }
-        ))
+//         section2.add(.disclosureItem(
+//             icon: .settingsStories,
+//             withText: OWSLocalizedString(
+//                 "STORY_SETTINGS_TITLE",
+//                 comment: "Label for the stories section of the settings view"
+//             ),
+//             actionBlock: { [weak self] in
+//                 let vc = StoryPrivacySettingsViewController()
+//                 self?.navigationController?.pushViewController(vc, animated: true)
+//             }
+//         ))
         section2.add(.disclosureItem(
             icon: .settingsNotifications,
             withText: OWSLocalizedString("SETTINGS_NOTIFICATIONS", comment: "The title for the notification settings."),
@@ -280,78 +280,78 @@ class AppSettingsViewController: OWSTableViewController2 {
         ))
         contents.add(section2)
 
-        if SUIEnvironment.shared.paymentsRef.shouldShowPaymentsUI {
-            let paymentsSection = OWSTableSection()
-            paymentsSection.add(.init(
-                customCellBlock: {
-                    let cell = OWSTableItem.newCell()
-                    cell.preservesSuperviewLayoutMargins = true
-                    cell.contentView.preservesSuperviewLayoutMargins = true
-
-                    var subviews = [UIView]()
-
-                    let iconView = OWSTableItem.imageView(forIcon: .settingsPayments,
-                                                          tintColor: nil,
-                                                          iconSize: OWSTableItem.iconSize)
-                    iconView.setCompressionResistanceHorizontalHigh()
-                    subviews.append(iconView)
-                    subviews.append(UIView.spacer(withWidth: OWSTableItem.iconSpacing))
-
-                    let nameLabel = UILabel()
-                    nameLabel.text = OWSLocalizedString("SETTINGS_PAYMENTS_TITLE",
-                                                       comment: "Label for the 'payments' section of the app settings.")
-                    nameLabel.textColor = Theme.primaryTextColor
-                    nameLabel.font = OWSTableItem.primaryLabelFont
-                    nameLabel.adjustsFontForContentSizeCategory = true
-                    nameLabel.numberOfLines = 0
-                    nameLabel.lineBreakMode = .byWordWrapping
-                    nameLabel.setContentHuggingLow()
-                    nameLabel.setCompressionResistanceHigh()
-                    subviews.append(nameLabel)
-
-                    subviews.append(UIView.hStretchingSpacer())
-
-                    let unreadPaymentsCount = SSKEnvironment.shared.databaseStorageRef.read { transaction in
-                        PaymentFinder.unreadCount(transaction: transaction)
-                    }
-                    if unreadPaymentsCount > 0 {
-                        let unreadLabel = UILabel()
-                        unreadLabel.text = OWSFormat.formatUInt(min(9, unreadPaymentsCount))
-                        unreadLabel.font = .dynamicTypeBody2Clamped
-                        unreadLabel.textColor = .ows_white
-
-                        let unreadBadge = OWSLayerView.circleView()
-                        unreadBadge.backgroundColor = .ows_accentBlue
-                        unreadBadge.addSubview(unreadLabel)
-                        unreadLabel.autoCenterInSuperview()
-                        unreadLabel.autoPinEdge(toSuperviewEdge: .top, withInset: 3)
-                        unreadLabel.autoPinEdge(toSuperviewEdge: .bottom, withInset: 3)
-                        unreadBadge.autoPinToSquareAspectRatio()
-                        unreadBadge.setContentHuggingHorizontalHigh()
-                        unreadBadge.setCompressionResistanceHorizontalHigh()
-                        subviews.append(unreadBadge)
-                    }
-
-                    let contentRow = UIStackView(arrangedSubviews: subviews)
-                    contentRow.alignment = .center
-                    cell.contentView.addSubview(contentRow)
-
-                    contentRow.setContentHuggingHigh()
-                    contentRow.autoPinEdgesToSuperviewMargins()
-                    contentRow.autoSetDimension(.height, toSize: OWSTableItem.iconSize, relation: .greaterThanOrEqual)
-
-                    cell.accessibilityIdentifier = UIView.accessibilityIdentifier(in: self, name: "payments")
-                    cell.accessoryType = .disclosureIndicator
-
-                    return cell
-                },
-                actionBlock: { [weak self, appReadiness] in
-                    let vc = PaymentsSettingsViewController(mode: .inAppSettings, appReadiness: appReadiness)
-                    self?.navigationController?.pushViewController(vc, animated: true)
-                }
-            ))
-            contents.add(paymentsSection)
-        }
+//         if SUIEnvironment.shared.paymentsRef.shouldShowPaymentsUI {
+//             let paymentsSection = OWSTableSection()
+//             paymentsSection.add(.init(
+//                 customCellBlock: {
+//                     let cell = OWSTableItem.newCell()
+//                     cell.preservesSuperviewLayoutMargins = true
+//                     cell.contentView.preservesSuperviewLayoutMargins = true
+// 
+//                     var subviews = [UIView]()
+// 
+//                     let iconView = OWSTableItem.imageView(forIcon: .settingsPayments,
+//                                                           tintColor: nil,
+//                                                           iconSize: OWSTableItem.iconSize)
+//                     iconView.setCompressionResistanceHorizontalHigh()
+//                     subviews.append(iconView)
+//                     subviews.append(UIView.spacer(withWidth: OWSTableItem.iconSpacing))
+// 
+//                     let nameLabel = UILabel()
+//                     nameLabel.text = OWSLocalizedString("SETTINGS_PAYMENTS_TITLE",
+//                                                        comment: "Label for the 'payments' section of the app settings.")
+//                     nameLabel.textColor = Theme.primaryTextColor
+//                     nameLabel.font = OWSTableItem.primaryLabelFont
+//                     nameLabel.adjustsFontForContentSizeCategory = true
+//                     nameLabel.numberOfLines = 0
+//                     nameLabel.lineBreakMode = .byWordWrapping
+//                     nameLabel.setContentHuggingLow()
+//                     nameLabel.setCompressionResistanceHigh()
+//                     subviews.append(nameLabel)
+// 
+//                     subviews.append(UIView.hStretchingSpacer())
+// 
+//                     let unreadPaymentsCount = SSKEnvironment.shared.databaseStorageRef.read { transaction in
+//                         PaymentFinder.unreadCount(transaction: transaction)
+//                     }
+//                     if unreadPaymentsCount > 0 {
+//                         let unreadLabel = UILabel()
+//                         unreadLabel.text = OWSFormat.formatUInt(min(9, unreadPaymentsCount))
+//                         unreadLabel.font = .dynamicTypeBody2Clamped
+//                         unreadLabel.textColor = .ows_white
+// 
+//                         let unreadBadge = OWSLayerView.circleView()
+//                         unreadBadge.backgroundColor = .ows_accentBlue
+//                         unreadBadge.addSubview(unreadLabel)
+//                         unreadLabel.autoCenterInSuperview()
+//                         unreadLabel.autoPinEdge(toSuperviewEdge: .top, withInset: 3)
+//                         unreadLabel.autoPinEdge(toSuperviewEdge: .bottom, withInset: 3)
+//                         unreadBadge.autoPinToSquareAspectRatio()
+//                         unreadBadge.setContentHuggingHorizontalHigh()
+//                         unreadBadge.setCompressionResistanceHorizontalHigh()
+//                         subviews.append(unreadBadge)
+//                     }
+// 
+//                     let contentRow = UIStackView(arrangedSubviews: subviews)
+//                     contentRow.alignment = .center
+//                     cell.contentView.addSubview(contentRow)
+// 
+//                     contentRow.setContentHuggingHigh()
+//                     contentRow.autoPinEdgesToSuperviewMargins()
+//                     contentRow.autoSetDimension(.height, toSize: OWSTableItem.iconSize, relation: .greaterThanOrEqual)
+// 
+//                     cell.accessibilityIdentifier = UIView.accessibilityIdentifier(in: self, name: "payments")
+//                     cell.accessoryType = .disclosureIndicator
+// 
+//                     return cell
+//                 },
+//                 actionBlock: { [weak self, appReadiness] in
+//                     let vc = PaymentsSettingsViewController(mode: .inAppSettings, appReadiness: appReadiness)
+//                     self?.navigationController?.pushViewController(vc, animated: true)
+//                 }
+//             ))
+//             contents.add(paymentsSection)
+//         }
 
         let section3 = OWSTableSection()
         section3.add(.disclosureItem(


### PR DESCRIPTION
## Summary
- comment out donate, stories, and payments items so they no longer appear in App Settings

## Testing
- `make test` *(fails: Interrupt during pod setup)*

------
https://chatgpt.com/codex/tasks/task_e_688e0338f77c8327aa6202068f0d86ba