### PR TITLE
Remove spam challenge resolver

### DIFF
--- a/Signal/AppLaunch/AppDelegate.swift
+++ b/Signal/AppLaunch/AppDelegate.swift
@@ -1491,13 +1491,6 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     private nonisolated func handleSilentPushContent(_ remoteNotification: [AnyHashable: Any]) async throws -> HandleSilentPushContentResult {
-        if let spamChallengeToken = remoteNotification["rateLimitChallenge"] as? String {
-            SSKEnvironment.shared.spamChallengeResolverRef.handleIncomingPushChallengeToken(spamChallengeToken)
-            // TODO: Wait only until the token has been submitted.
-            try await Task.sleep(nanoseconds: 20.clampedNanoseconds)
-            return .handled
-        }
-
         if let preAuthChallengeToken = remoteNotification["challenge"] as? String {
             AppEnvironment.shared.pushRegistrationManagerRef.didReceiveVanillaPreAuthChallengeToken(preAuthChallengeToken)
             // TODO: Wait only until the token has been submitted.

--- a/Signal/AppLaunch/SignalApp.swift
+++ b/Signal/AppLaunch/SignalApp.swift
@@ -74,13 +74,6 @@ extension SignalApp {
         let formattedStartupDuration = String(format: "%.3f", startupDuration)
         Logger.info("Presenting app \(formattedStartupDuration) seconds after launch started.")
 
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(spamChallenge),
-            name: SpamChallengeResolver.NeedsCaptchaNotification,
-            object: nil
-        )
-
         switch launchInterface {
         case .registration(let registrationLoader, let desiredMode):
             showRegistration(loader: registrationLoader, desiredMode: desiredMode, appReadiness: appReadiness)
@@ -126,11 +119,6 @@ extension SignalApp {
         UIApplication.shared.delegate?.window??.rootViewController = navController
 
         conversationSplitViewController = nil
-    }
-
-    @objc
-    private func spamChallenge() {
-        SpamCaptchaViewController.presentActionSheet(from: AppEnvironment.shared.windowManagerRef.captchaWindow.findFrontmostViewController(ignoringAlerts: true)!)
     }
 
     @objc

--- a/Signal/Calls/UserInterface/GroupCallViewController.swift
+++ b/Signal/Calls/UserInterface/GroupCallViewController.swift
@@ -333,13 +333,6 @@ final class GroupCallViewController: UIViewController {
             object: nil
         )
 
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(didCompleteAnySpamChallenge),
-            name: SpamChallengeResolver.didCompleteAnyChallenge,
-            object: nil
-        )
-
         self.callLinkLobbyToastLabel.text = switch phoneNumberSharingMode {
         case .everybody:
             OWSLocalizedString(
@@ -684,12 +677,6 @@ final class GroupCallViewController: UIViewController {
         if hasUnresolvedSafetyNumberMismatch {
             resolveSafetyNumberMismatch()
         }
-    }
-
-    @objc
-    private func didCompleteAnySpamChallenge() {
-        AppEnvironment.shared.callLinkProfileKeySharingManager.sendProfileKeyToParticipants(ofCall: self.groupCall)
-        self.ringRtcCall.resendMediaKeys()
     }
 
     // MARK: Call members

--- a/Signal/ConversationView/ConversationViewController+CVComponentDelegate.swift
+++ b/Signal/ConversationView/ConversationViewController+CVComponentDelegate.swift
@@ -911,12 +911,6 @@ extension ConversationViewController: CVComponentDelegate {
 
     public func didTapPendingOutgoingMessage(_ message: TSOutgoingMessage) {
         AssertIsOnMainThread()
-        if SSKEnvironment.shared.spamChallengeResolverRef.isPausingMessages {
-            SpamCaptchaViewController.presentActionSheet(from: self)
-        } else {
-            SSKEnvironment.shared.spamChallengeResolverRef.retryPausedMessagesIfReady()
-        }
-
     }
 
     public func didTapFailedOutgoingMessage(_ message: TSOutgoingMessage) {

--- a/SignalServiceKit/Environment/AppSetup.swift
+++ b/SignalServiceKit/Environment/AppSetup.swift
@@ -1576,7 +1576,6 @@ public class AppSetup {
         let sskPreferences = SSKPreferences()
         let groupV2Updates = testDependencies.groupV2Updates ?? GroupV2UpdatesImpl(appReadiness: appReadiness)
         let paymentsCurrencies = testDependencies.paymentsCurrencies ?? PaymentsCurrenciesImpl(appReadiness: appReadiness)
-        let spamChallengeResolver = SpamChallengeResolver(appReadiness: appReadiness)
         let phoneNumberUtil = PhoneNumberUtil()
         let contactDiscoveryManager = ContactDiscoveryManagerImpl(
             db: db,
@@ -1650,7 +1649,6 @@ public class AppSetup {
             paymentsEvents: paymentsEvents,
             paymentsLock: paymentsLock,
             mobileCoinHelper: mobileCoinHelper,
-            spamChallengeResolver: spamChallengeResolver,
             senderKeyStore: senderKeyStore,
             phoneNumberUtil: phoneNumberUtil,
             webSocketFactory: webSocketFactory,

--- a/SignalServiceKit/Messages/MessageSender+SenderKey.swift
+++ b/SignalServiceKit/Messages/MessageSender+SenderKey.swift
@@ -529,19 +529,6 @@ extension MessageSender {
                         }
                     }
                     throw SenderKeyError.staleDevices
-                case 428:
-                    guard let body = responseData, let expiry = error.httpRetryAfterDate else {
-                        throw OWSAssertionError("Invalid spam response body")
-                    }
-                    try await withCheckedThrowingContinuation { continuation in
-                        SSKEnvironment.shared.spamChallengeResolverRef.handleServerChallengeBody(body, retryAfter: expiry) { didSucceed in
-                            if didSucceed {
-                                continuation.resume()
-                            } else {
-                                continuation.resume(throwing: SpamChallengeRequiredError())
-                            }
-                        }
-                    }
                 default:
                     break
                 }

--- a/SignalServiceKit/Messages/MessageSender.swift
+++ b/SignalServiceKit/Messages/MessageSender.swift
@@ -1559,17 +1559,6 @@ public class MessageSender {
                 handleStaleDevices(serviceId: messageSend.serviceId, staleDevices: response.staleDevices, tx: tx)
             }
             throw DeviceMessagesError.staleDevices
-        case 428:
-            // SPAM TODO: Only retry messages with -hasRenderableContent
-            Logger.warn("Server requested user complete spam challenge.")
-            try await SSKEnvironment.shared.spamChallengeResolverRef.tryToHandleSilently(
-                bodyData: responseError.httpResponseData,
-                retryAfter: responseError.httpRetryAfterDate
-            )
-            // The resolver has 10s to asynchronously resolve a challenge If it
-            // resolves, great! We'll let MessageSender auto-retry. Otherwise, it'll be
-            // marked as "pending"
-            throw responseError
         default:
             throw responseError
         }

--- a/SignalServiceKit/SSKEnvironment.swift
+++ b/SignalServiceKit/SSKEnvironment.swift
@@ -77,7 +77,6 @@ public class SSKEnvironment: NSObject {
     public let paymentsEventsRef: PaymentsEvents
     public let owsPaymentsLockRef: OWSPaymentsLock
     public let mobileCoinHelperRef: MobileCoinHelper
-    public let spamChallengeResolverRef: SpamChallengeResolver
     public let senderKeyStoreRef: SenderKeyStore
     public let phoneNumberUtilRef: PhoneNumberUtil
     public let webSocketFactoryRef: WebSocketFactory
@@ -144,7 +143,6 @@ public class SSKEnvironment: NSObject {
         paymentsEvents: PaymentsEvents,
         paymentsLock: OWSPaymentsLock,
         mobileCoinHelper: MobileCoinHelper,
-        spamChallengeResolver: SpamChallengeResolver,
         senderKeyStore: SenderKeyStore,
         phoneNumberUtil: PhoneNumberUtil,
         webSocketFactory: WebSocketFactory,
@@ -205,7 +203,6 @@ public class SSKEnvironment: NSObject {
         self.paymentsEventsRef = paymentsEvents
         self.owsPaymentsLockRef = paymentsLock
         self.mobileCoinHelperRef = mobileCoinHelper
-        self.spamChallengeResolverRef = spamChallengeResolver
         self.senderKeyStoreRef = senderKeyStore
         self.phoneNumberUtilRef = phoneNumberUtil
         self.webSocketFactoryRef = webSocketFactory

--- a/SignalUI/ViewControllers/SpamCaptchaViewController.swift
+++ b/SignalUI/ViewControllers/SpamCaptchaViewController.swift
@@ -143,14 +143,7 @@ extension SpamCaptchaViewController {
 
     static func presentCaptchaVC(from fromVC: UIViewController) {
         let vc = SpamCaptchaViewController()
-        vc.completionHandler = { token in
-            if let token = token {
-                fromVC.presentToast(
-                    text: OWSLocalizedString(
-                        "SPAM_CAPTCHA_COMPLETED_TOAST",
-                        comment: "Text for toast presented after spam verification has been completed"))
-                SSKEnvironment.shared.spamChallengeResolverRef.handleIncomingCaptchaChallengeToken(token)
-            }
+        vc.completionHandler = { _ in
             vc.dismiss(animated: true)
         }
         let navVC = OWSNavigationController(rootViewController: vc)


### PR DESCRIPTION
## Summary
- remove rateLimitChallenge handling from silent push flow
- drop SpamChallenge observer and actions
- excise SpamChallengeResolver from environment and related code

## Testing
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a96b9ac038832798f76e5d9cb02a58