### PR TITLE
Use debug-only assertion in owsFailDebug

### DIFF
--- a/SignalServiceKit/OWSAsserts/OWSSwiftUtils.swift
+++ b/SignalServiceKit/OWSAsserts/OWSSwiftUtils.swift
@@ -44,15 +44,19 @@ public func owsFailDebug(
     function: String = #function,
     line: Int = #line
 ) {
-    logger.error(logMessage, file: file, function: function, line: line)
     if IsDebuggerAttached() {
+        logger.error(logMessage, file: file, function: function, line: line)
         TrapDebugger()
     } else if Preferences.isFailDebugEnabled {
+        logger.error(logMessage, file: file, function: function, line: line)
         Preferences.setIsFailDebugEnabled(false)
         logger.flush()
         fatalError(logMessage)
     } else {
-        assertionFailure(logMessage)
+        logger.error(logMessage, file: file, function: function, line: line)
+        if _isDebugAssertConfiguration() {
+            assertionFailure(logMessage)
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- guard `assertionFailure` with `_isDebugAssertConfiguration()` in `owsFailDebug`
- log error messages during release builds instead of trapping

## Testing
- `swiftc -Onone /tmp/test.swift -o /tmp/test_debug && /tmp/test_debug` *(fails: should assert)*
- `swiftc -O /tmp/test.swift -o /tmp/test_release && /tmp/test_release`
- `make test` *(fails: Fetched in submodule path 'Pods', but it did not contain commit)*

------
https://chatgpt.com/codex/tasks/task_e_68bbe5025f70832785b25817609437de