### PR TITLE
Add single-button account registration flow

### DIFF
--- a/Signal/Registration/UserInterface/RegistrationCreateAccountViewController.swift
+++ b/Signal/Registration/UserInterface/RegistrationCreateAccountViewController.swift
@@ -1,0 +1,56 @@
+import Foundation
+import SignalServiceKit
+import SignalUI
+
+class RegistrationCreateAccountViewController: OWSViewController {
+    private weak var presenter: RegistrationPhoneNumberPresenter?
+
+    init(presenter: RegistrationPhoneNumberPresenter) {
+        self.presenter = presenter
+        super.init()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        owsFail("init(coder:) is not supported")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        view.backgroundColor = Theme.backgroundColor
+
+        let logoImageView = UIImageView(image: UIImage(named: "signal-logo-128"))
+        logoImageView.contentMode = .scaleAspectFit
+        view.addSubview(logoImageView)
+        logoImageView.autoCenterInSuperview()
+        logoImageView.autoSetDimensions(to: .square(128))
+
+        let button = OWSFlatButton.primaryButtonForRegistration(title: "CREATE ACCOUNT", target: self, selector: #selector(createAccount))
+        button.autoSetDimension(.height, toSize: 50)
+        view.addSubview(button)
+        button.autoPinEdge(toSuperviewSafeArea: .leading, withInset: 20)
+        button.autoPinEdge(toSuperviewSafeArea: .trailing, withInset: 20)
+        button.autoPinEdge(toSuperviewSafeArea: .bottom, withInset: 20)
+    }
+
+    @objc
+    private func createAccount() {
+        let randomNumber = Self.randomE164()
+        presenter?.goToNextStep(withE164: randomNumber)
+    }
+
+    private static func randomE164() -> E164 {
+        let country = PhoneNumberCountry.defaultValue
+        // Use country calling code and random 10-digit national number.
+        var digits = String(Int.random(in: 2...9))
+        for _ in 0..<9 {
+            digits.append(String(Int.random(in: 0...9)))
+        }
+        let e164String = country.plusPrefixedCallingCode + digits
+        guard let e164 = E164(e164String) else {
+            owsFail("Failed to generate random E164")
+        }
+        return e164
+    }
+}

--- a/Signal/Registration/UserInterface/RegistrationLoadingViewController.swift
+++ b/Signal/Registration/UserInterface/RegistrationLoadingViewController.swift
@@ -19,12 +19,12 @@ class RegistrationLoadingViewController: OWSViewController {
             switch mode {
             case .generic:
                 return ""
-            case let .submittingPhoneNumber(e164):
+            case .submittingPhoneNumber(_):
                 let format = OWSLocalizedString(
                     "REGISTRATION_VIEW_PHONE_NUMBER_SPINNER_LABEL_FORMAT",
                     comment: "Label for the progress spinner shown during phone number registration. Embeds {{phone number}}."
                 )
-                return String(format: format, e164.e164FormattedAsPhoneNumberWithoutBreaks)
+                return String(format: format, "").replacingOccurrences(of: " ...", with: "...")
             case .submittingVerificationCode:
                 return OWSLocalizedString(
                     "ONBOARDING_VERIFICATION_CODE_VALIDATION_PROGRESS_LABEL",

--- a/Signal/Registration/UserInterface/RegistrationNavigationController.swift
+++ b/Signal/Registration/UserInterface/RegistrationNavigationController.swift
@@ -204,17 +204,14 @@ public class RegistrationNavigationController: OWSNavigationController {
             )
         case .phoneNumberEntry(let state):
             switch state {
-            case .registration(let registrationMode):
+            case .registration(_):
                 return Controller(
-                    type: RegistrationPhoneNumberViewController.self,
+                    type: RegistrationCreateAccountViewController.self,
                     canCancel: true,
                     make: { presenter in
-                        return RegistrationPhoneNumberViewController(state: registrationMode, presenter: presenter)
+                        return RegistrationCreateAccountViewController(presenter: presenter)
                     },
-                    update: { controller in
-                        controller.updateState(registrationMode)
-                        return nil
-                    }
+                    update: nil
                 )
             case .changingNumber(let changingNumberMode):
                 switch changingNumberMode {


### PR DESCRIPTION
## Summary
- Introduce `RegistrationCreateAccountViewController` with a single CREATE ACCOUNT button that auto-generates a phone number and moves to the next step
- Replace phone number entry screen with the new controller in registration flow
- Remove project file updates so it can be edited manually
- Center logo image and bottom-anchor the CREATE ACCOUNT button to match existing text field height
- Hide phone number on verification loading screen, showing generic verifying text instead

## Testing
- `make test` *(fails: fatal: remote error: upload-pack: not our ref f67f9210c416e397063207941cafb86e82c92563)*

------
https://chatgpt.com/codex/tasks/task_e_68beae3d258883278e1401e42832db88