### PR TITLE
Disable Get Started banner and hide phone number/backups entries

### DIFF
--- a/Signal/src/ViewControllers/AppSettings/Account/AccountSettingsViewController.swift
+++ b/Signal/src/ViewControllers/AppSettings/Account/AccountSettingsViewController.swift
@@ -146,6 +146,8 @@ class AccountSettingsViewController: OWSTableViewController2 {
             case .disallowed:
                 break
             case .allowed:
+                break
+                /*
                 accountSection.add(.actionItem(
                     withText: OWSLocalizedString("SETTINGS_CHANGE_PHONE_NUMBER_BUTTON", comment: "Label for button in settings views to change phone number"),
                     accessibilityIdentifier: UIView.accessibilityIdentifier(in: self, name: "change_phone_number"),
@@ -163,6 +165,7 @@ class AccountSettingsViewController: OWSTableViewController2 {
                         }
                     }
                 ))
+                */
             }
             accountSection.add(.actionItem(
                 withText: OWSLocalizedString(

--- a/Signal/src/ViewControllers/AppSettings/AppSettingsViewController.swift
+++ b/Signal/src/ViewControllers/AppSettings/AppSettingsViewController.swift
@@ -241,6 +241,8 @@ class AppSettingsViewController: OWSTableViewController2 {
                 self?.navigationController?.pushViewController(vc, animated: true)
             }
         ))
+        // The Backups entry has been intentionally hidden from the settings menu.
+        /*
         if
             isPrimaryDevice,
             RemoteConfig.current.allowBackupSettings
@@ -270,6 +272,7 @@ class AppSettingsViewController: OWSTableViewController2 {
                 }
             ))
         }
+        */
         section2.add(.disclosureItem(
             icon: .settingsDataUsage,
             withText: OWSLocalizedString("SETTINGS_DATA", comment: "Label for the 'data' section of the app settings."),
@@ -476,6 +479,8 @@ class AppSettingsViewController: OWSTableViewController2 {
             return containerView
         }
 
+        // The profile cell should no longer display the account phone number.
+        /*
         if let phoneNumber = DependenciesBridge.shared.tsAccountManager.localIdentifiersWithMaybeSneakyTransaction?.phoneNumber {
             addSubtitleLabel(
                 text: PhoneNumber.bestEffortFormatPartialUserSpecifiedTextToLookLikeAPhoneNumber(phoneNumber),
@@ -484,6 +489,7 @@ class AppSettingsViewController: OWSTableViewController2 {
         } else {
             owsFailDebug("Missing local number")
         }
+        */
 
         if let localUsernameState {
             switch localUsernameState {

--- a/Signal/src/ViewControllers/AppSettings/Internal/InternalSettingsViewController.swift
+++ b/Signal/src/ViewControllers/AppSettings/Internal/InternalSettingsViewController.swift
@@ -126,6 +126,8 @@ class InternalSettingsViewController: OWSTableViewController2 {
 
         contents.add(debugSection)
 
+        // The Backups section has been intentionally hidden from the internal menu.
+        /*
         let backupsSection = OWSTableSection(title: "Backups")
 
         if mode != .registration {
@@ -171,6 +173,7 @@ class InternalSettingsViewController: OWSTableViewController2 {
         if backupsSection.items.isEmpty.negated {
             contents.add(backupsSection)
         }
+        */
 
         let (
             contactThreadCount,
@@ -192,7 +195,8 @@ class InternalSettingsViewController: OWSTableViewController2 {
 
         let regSection = OWSTableSection(title: "Account")
         let localIdentifiers = DependenciesBridge.shared.tsAccountManager.localIdentifiersWithMaybeSneakyTransaction
-        regSection.add(.copyableItem(label: "Phone Number", value: localIdentifiers?.phoneNumber))
+        // Phone number intentionally hidden from the internal settings menu.
+        // regSection.add(.copyableItem(label: "Phone Number", value: localIdentifiers?.phoneNumber))
         regSection.add(.copyableItem(label: "ACI", value: localIdentifiers?.aci.serviceIdString))
         regSection.add(.copyableItem(label: "PNI", value: localIdentifiers?.pni?.serviceIdString))
         regSection.add(.copyableItem(label: "Device ID", value: "\(DependenciesBridge.shared.tsAccountManager.storedDeviceIdWithMaybeTransaction)"))

--- a/Signal/src/ViewControllers/HomeView/Chat List/ChatListViewController.swift
+++ b/Signal/src/ViewControllers/HomeView/Chat List/ChatListViewController.swift
@@ -1292,6 +1292,8 @@ extension ChatListViewController: ThreadSwipeHandler {
 
 extension ChatListViewController: GetStartedBannerViewControllerDelegate {
     func presentGetStartedBannerIfNecessary() {
+        // The "Get Started" banner has been intentionally disabled.
+        /*
         guard getStartedBanner == nil && viewState.chatListMode == .inbox else { return }
 
         let getStartedVC = GetStartedBannerViewController(delegate: self)
@@ -1308,6 +1310,7 @@ extension ChatListViewController: GetStartedBannerViewControllerDelegate {
                 getStartedVC.view.alpha = 0
             }
         }
+        */
     }
 
     func getStartedBannerDidTapInviteFriends(_ banner: GetStartedBannerViewController) {


### PR DESCRIPTION
## Summary
- comment out the chat list Get Started banner so it no longer appears on the home screen
- hide phone number displays across settings, including the internal menu, while keeping the code for reference
- comment out Backups entries in both user and internal settings menus

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cc0cce40a88327a2428af8b0732601