### PR TITLE
Remove backups entry from settings

### DIFF
--- a/Signal/src/ViewControllers/AppSettings/AppSettingsViewController.swift
+++ b/Signal/src/ViewControllers/AppSettings/AppSettingsViewController.swift
@@ -241,35 +241,6 @@ class AppSettingsViewController: OWSTableViewController2 {
                 self?.navigationController?.pushViewController(vc, animated: true)
             }
         ))
-        if
-            isPrimaryDevice,
-            RemoteConfig.current.allowBackupSettings
-        {
-            section2.add(.disclosureItem(
-                icon: .backup,
-                withText: OWSLocalizedString(
-                    "SETTINGS_BACKUPS",
-                    comment: "Label for the 'backups' section of app settings."
-                ),
-                actionBlock: { [weak self] in
-                    guard let self else { return }
-
-                    let backupSettingsStore = BackupSettingsStore()
-                    let db = DependenciesBridge.shared.db
-
-                    let haveBackupsEverBeenEnabled = db.read { tx in
-                        backupSettingsStore.haveBackupsEverBeenEnabled(tx: tx)
-                    }
-
-                    if haveBackupsEverBeenEnabled {
-                        let vc = BackupSettingsViewController(onLoadAction: .none)
-                        navigationController?.pushViewController(vc, animated: true)
-                    } else {
-                        BackupOnboardingCoordinator().present(fromViewController: self)
-                    }
-                }
-            ))
-        }
         section2.add(.disclosureItem(
             icon: .settingsDataUsage,
             withText: OWSLocalizedString("SETTINGS_DATA", comment: "Label for the 'data' section of the app settings."),


### PR DESCRIPTION
## Summary
- remove the backups item from the app settings table view to hide backup configuration entry

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cc1306b5a88327a06848333ad6e67f