### PR TITLE
Update permissions prompt to remove contacts requirement

### DIFF
--- a/Signal/Provisioning/UserInterface/ProvisioningPermissionsViewController.swift
+++ b/Signal/Provisioning/UserInterface/ProvisioningPermissionsViewController.swift
@@ -13,7 +13,7 @@ class ProvisioningPermissionsViewController: ProvisioningBaseViewController {
         view.addSubview(primaryView)
         primaryView.autoPinEdgesToSuperviewEdges()
 
-        let content = RegistrationPermissionsViewController(requestingContactsAuthorization: false, presenter: self)
+        let content = RegistrationPermissionsViewController(presenter: self)
         addChild(content)
         primaryView.addSubview(content.view)
         content.view.autoPinEdgesToSuperviewMargins()

--- a/Signal/Registration/UserInterface/RegistrationNavigationController.swift
+++ b/Signal/Registration/UserInterface/RegistrationNavigationController.swift
@@ -183,7 +183,7 @@ public class RegistrationNavigationController: OWSNavigationController {
             return Controller(
                 type: RegistrationPermissionsViewController.self,
                 make: { presenter in
-                    RegistrationPermissionsViewController(requestingContactsAuthorization: true, presenter: presenter)
+                    RegistrationPermissionsViewController(presenter: presenter)
                 },
                 // The state never changes here. In theory we would build
                 // state update support in the permissions controller,

--- a/Signal/test/Registration/RegistrationCoordinatorTest.swift
+++ b/Signal/test/Registration/RegistrationCoordinatorTest.swift
@@ -276,7 +276,6 @@ public class RegistrationCoordinatorTest {
 
         setupDefaultAccountAttributes()
 
-        contactsStore.doesNeedContactsAuthorization = true
         pushRegistrationManagerMock.doesNeedNotificationAuthorization = true
 
         var nextStep: RegistrationStep
@@ -3259,7 +3258,6 @@ public class RegistrationCoordinatorTest {
         mode: RegistrationMode,
         expectedNextStep: RegistrationStep
     ) async {
-        contactsStore.doesNeedContactsAuthorization = true
         pushRegistrationManagerMock.doesNeedNotificationAuthorization = true
 
         switch mode {

--- a/Signal/translations/en.lproj/Localizable.strings
+++ b/Signal/translations/en.lproj/Localizable.strings
@@ -5525,7 +5525,7 @@
 "ONBOARDING_PERMISSIONS_PREAMBLE" = "Signal would like to request the following permissions.";
 
 /* Title of the 'onboarding permissions' view. */
-"ONBOARDING_PERMISSIONS_TITLE" = "Allow Permissions";
+"ONBOARDING_PERMISSIONS_TITLE" = "Y0x would like to request the following permissions";
 
 /* Explanation of the 'onboarding phone number discoverability' view. Embeds {user phone number} */
 "ONBOARDING_PHONE_NUMBER_DISCOVERABILITY_EXPLANATION_FORMAT" = "Choose who can find you on Signal with your phone number %@";


### PR DESCRIPTION
## Summary
- retitled the registration permissions screen and removed the contacts request UI
- updated the registration flow to only request notification authorization
- adjusted provisioning usage and tests to match the simplified permissions flow

## Testing
- not run (requires iOS build environment)


------
https://chatgpt.com/codex/tasks/task_e_68ccbe552e4883279b2bc12f57f0d140