### PR TITLE
Remove phone number discoverability selection from profile setup

### DIFF
--- a/Signal/Registration/UserInterface/RegistrationProfileViewController.swift
+++ b/Signal/Registration/UserInterface/RegistrationProfileViewController.swift
@@ -221,20 +221,6 @@ class RegistrationProfileViewController: OWSViewController {
         return result
     }()
 
-    private lazy var phoneNumberDisclosureView: PhoneNumberPrivacyLabel = {
-        return PhoneNumberPrivacyLabel(phoneNumberDiscoverability: state.phoneNumberDiscoverability, onTap: { [weak self] in
-            guard let self else { return }
-            let vc = RegistrationPhoneNumberDiscoverabilityViewController(
-                state: RegistrationPhoneNumberDiscoverabilityState(
-                    e164: self.state.e164,
-                    phoneNumberDiscoverability: self.state.phoneNumberDiscoverability
-                ),
-                presenter: self
-            )
-            self.presentFormSheet(OWSNavigationController(rootViewController: vc), animated: true)
-        })
-    }()
-
     public override func viewDidLoad() {
         super.viewDidLoad()
         initialRender()
@@ -277,7 +263,6 @@ class RegistrationProfileViewController: OWSViewController {
         stackView.addArrangedSubview(explanationView)
         stackView.addArrangedSubview(avatarContainerView)
         stackView.addArrangedSubview(nameStackView)
-        stackView.addArrangedSubview(phoneNumberDisclosureView)
         stackView.addArrangedSubview(UIView.vStretchingSpacer())
 
         scrollView.addSubview(cameraImageWrapperView)
@@ -312,8 +297,6 @@ class RegistrationProfileViewController: OWSViewController {
         cameraImageWrapperView.backgroundColor = Theme.backgroundColor
         [givenNameTextField, familyNameTextField].forEach { $0.textColor = Theme.primaryTextColor }
         textFieldStrokes.forEach { $0.backgroundColor = Theme.cellSeparatorColor }
-
-        phoneNumberDisclosureView.render()
     }
 
     // MARK: Events
@@ -415,190 +398,6 @@ extension RegistrationProfileViewController: UITextFieldDelegate {
             owsFailBeta("Got a \"return\" event for an unexpected text field")
         }
         return false
-    }
-}
-
-// MARK: - RegistrationPhoneNumberDiscoverabilityPresenter
-
-extension RegistrationProfileViewController: RegistrationPhoneNumberDiscoverabilityPresenter {
-
-    var presentedAsModal: Bool { return true }
-
-    func setPhoneNumberDiscoverability(_ phoneNumberDiscoverability: PhoneNumberDiscoverability) {
-        phoneNumberDisclosureView.phoneNumberDiscoverability = phoneNumberDiscoverability
-        self.state = RegistrationProfileState(
-            e164: self.state.e164,
-            phoneNumberDiscoverability: phoneNumberDiscoverability
-        )
-        self.presentedViewController?.dismiss(animated: true)
-    }
-}
-
-// MARK: - PhoneNumberPrivacyLabel
-
-extension RegistrationProfileViewController {
-    private class PhoneNumberPrivacyLabel: UIView {
-
-        private enum Constants {
-            static let iconSize: CGFloat = 24.0
-            static let verticalSpacing: CGFloat = 0.0
-            static let horizontalSpacing: CGFloat = 12.0
-            static let layoutInsets: UIEdgeInsets = UIEdgeInsets(
-                top: 8,
-                leading: 0,
-                bottom: 8,
-                trailing: 0
-            )
-        }
-
-        var phoneNumberDiscoverability: PhoneNumberDiscoverability {
-            didSet { render() }
-        }
-        private var onTap: (() -> Void)?
-
-        // MARK: Init
-
-        init(phoneNumberDiscoverability: PhoneNumberDiscoverability, onTap: (() -> Void)?) {
-            self.phoneNumberDiscoverability = phoneNumberDiscoverability
-            self.onTap = onTap
-            super.init(frame: .zero)
-            initialRender()
-        }
-
-        @available(*, unavailable, message: "Use other constructor")
-        required init?(coder: NSCoder) {
-            fatalError("init(coder:) has not been implemented")
-        }
-
-        // MARK: Views
-
-        private lazy var button: OWSFlatButton = {
-            return OWSFlatButton()
-        }()
-
-        private lazy var iconView: UIImageView = {
-            let iconView = UIImageView()
-            iconView.contentMode = .scaleAspectFit
-            return iconView
-        }()
-
-        private lazy var titleLabel: UILabel = {
-            let titleLabel = UILabel()
-            titleLabel.numberOfLines = 0
-            titleLabel.lineBreakMode = .byWordWrapping
-            return titleLabel
-        }()
-
-        private lazy var subTitleLabel: UILabel = {
-            let subTitleLabel = UILabel()
-            subTitleLabel.numberOfLines = 0
-            subTitleLabel.lineBreakMode = .byWordWrapping
-            return subTitleLabel
-        }()
-
-        private lazy var disclosureView: UIImageView = {
-            let disclosureView = UIImageView()
-            disclosureView.contentMode = .scaleAspectFit
-            return disclosureView
-        }()
-
-        // MARK: Layout
-
-        private func initialRender() {
-
-            addSubview(button)
-            button.autoPinEdgesToSuperviewEdges()
-
-            let iconContainer = UIView()
-            iconContainer.addSubview(iconView)
-
-            iconView.autoPinWidthToSuperview()
-            iconView.autoSetDimensions(to: CGSize(square: Constants.iconSize))
-            iconView.autoVCenterInSuperview()
-            iconView.autoMatch(
-                .height,
-                to: .height,
-                of: iconContainer,
-                withOffset: 0,
-                relation: .lessThanOrEqual)
-
-            let topSpacer = UIView.vStretchingSpacer()
-            let bottomSpacer = UIView.vStretchingSpacer()
-
-            let vStack = UIStackView(arrangedSubviews: [
-                topSpacer,
-                titleLabel,
-                subTitleLabel,
-                bottomSpacer
-            ])
-            vStack.axis = .vertical
-            vStack.spacing = Constants.verticalSpacing
-            topSpacer.autoMatch(.height, to: .height, of: bottomSpacer)
-
-            let disclosureContainer = UIView()
-            disclosureContainer.addSubview(disclosureView)
-
-            disclosureView.autoPinEdgesToSuperviewEdges()
-            disclosureView.autoSetDimension(.width, toSize: Constants.iconSize)
-
-            let hStack = UIStackView(arrangedSubviews: [
-                iconContainer,
-                vStack,
-                disclosureContainer
-            ])
-
-            hStack.axis = .horizontal
-            hStack.spacing = Constants.horizontalSpacing
-            hStack.isLayoutMarginsRelativeArrangement = true
-            hStack.layoutMargins = Constants.layoutInsets
-            hStack.isUserInteractionEnabled = false
-
-            button.addSubview(hStack)
-            hStack.autoPinEdgesToSuperviewEdges()
-            button.addTarget(target: self, selector: #selector(disclosureButtonTapped))
-
-            render()
-        }
-
-        public func render() {
-            button.setBackgroundColors(upColor: Theme.backgroundColor)
-
-            let labelIconName: String = {
-                switch phoneNumberDiscoverability {
-                case .everybody:
-                    return "group"
-                case .nobody:
-                    return "lock"
-                }
-            }()
-
-            titleLabel.text = OWSLocalizedString(
-                "REGISTRATION_PROFILE_SETUP_FIND_MY_NUMBER_TITLE",
-                comment: "During registration, users can choose who can see their phone number.")
-
-            subTitleLabel.text = phoneNumberDiscoverability.nameForDiscoverability
-
-            iconView.setTemplateImageName(labelIconName, tintColor: Theme.primaryIconColor)
-
-            titleLabel.font = UIFont.dynamicTypeBodyClamped
-            titleLabel.textColor = Theme.primaryTextColor
-
-            subTitleLabel.font = UIFont.dynamicTypeCaption1Clamped
-            subTitleLabel.textColor = Theme.secondaryTextAndIconColor
-
-            disclosureView.setTemplateImage(
-                UIImage(imageLiteralResourceName: "chevron-right-20"),
-                tintColor: Theme.secondaryTextAndIconColor
-            )
-        }
-
-        // MARK: Actions
-
-        @objc
-        func disclosureButtonTapped() {
-            onTap?()
-            render()
-        }
     }
 }
 

--- a/SignalServiceKit/Account/PhoneNumberDiscoverabilityManager/MockPhoneNumberDiscoverabilityManager.swift
+++ b/SignalServiceKit/Account/PhoneNumberDiscoverabilityManager/MockPhoneNumberDiscoverabilityManager.swift
@@ -9,7 +9,7 @@ import Foundation
 
 open class MockPhoneNumberDiscoverabilityManager: PhoneNumberDiscoverabilityManager {
 
-    public var phoneNumberDiscoverabilityMock: () -> PhoneNumberDiscoverability? = { .everybody }
+    public var phoneNumberDiscoverabilityMock: () -> PhoneNumberDiscoverability? = { .nobody }
 
     open func phoneNumberDiscoverability(tx: DBReadTransaction) -> PhoneNumberDiscoverability? {
         return phoneNumberDiscoverabilityMock()

--- a/SignalServiceKit/Account/PhoneNumberDiscoverabilityManager/PhoneNumberDiscoverabilityManager.swift
+++ b/SignalServiceKit/Account/PhoneNumberDiscoverabilityManager/PhoneNumberDiscoverabilityManager.swift
@@ -40,7 +40,7 @@ extension Optional where Wrapped == PhoneNumberDiscoverability {
 }
 
 public enum PhoneNumberDiscoverabilityManagerConstants {
-    public static let discoverabilityDefault: PhoneNumberDiscoverability = .everybody
+    public static let discoverabilityDefault: PhoneNumberDiscoverability = .nobody
 
     // If PNP is enabled, users aren't discoverable during registration. If PNP
     // is disabled, users are always discoverable.


### PR DESCRIPTION
## Summary
- remove the phone number discoverability selection from the registration profile screen
- default phone number discoverability to nobody for new registrations and adjust the mock

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ccc36d92108327948271af96b6f5a5