### PR TITLE
Update build number to 2

### DIFF
--- a/Signal/Signal-Info.plist
+++ b/Signal/Signal-Info.plist
@@ -48,7 +48,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>2</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LOGS_EMAIL</key>

--- a/Signal/test/Supporting Files/SignalTests-Info.plist
+++ b/Signal/test/Supporting Files/SignalTests-Info.plist
@@ -17,6 +17,6 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>2</string>
 </dict>
 </plist>

--- a/SignalNSE/Info.plist
+++ b/SignalNSE/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
-	<string>0</string>
+	<string>2</string>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSExceptionDomains</key>

--- a/SignalShareExtension/Info.plist
+++ b/SignalShareExtension/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
-	<string>0</string>
+	<string>2</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>NSAppTransportSecurity</key>


### PR DESCRIPTION
## Summary
- set the app's CFBundleVersion to 2 in the main target and related extensions
- align the test bundle's build number with the new build version

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ccef66e93883279ee3213002a1aa48